### PR TITLE
Make field mappings more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,25 @@ detection:
 backend = SentinelOneBackend()
 print(backend.convert_rule(rule)[0])
 ```
+
+## Side Notes & Limitations
+- Backend uses Deep Visibility syntax
+- Pipeline uses Deep Visibility field names
+- Pipeline supports `linux`, `windows`, and `macos` product types
+- Pipeline supports the following category types for field mappings
+  - `process_creation`
+  - `file_event`
+  - `file_change`
+  - `file_rename`
+  - `file_delete`
+  - `image_load`
+  - `pipe_creation`
+  - `registry_add`
+  - `registry_delete`
+  - `registry_event`
+  - `registry_set`
+  - `dns_query`
+  - `dns`
+  - `network_connection`
+  - `firewall`
+- Any unsupported fields or categories will throw errors

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install pysigma-backend-sentinelone
 ```python
 from sigma.plugins import SigmaPluginDirectory
 plugins = SigmaPluginDirectory.default_plugin_directory()
-plugins.get_plugin_by_id("sentinelone).install()
+plugins.get_plugin_by_id("sentinelone").install()
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,3 +16,46 @@ It supports the following output formats:
 This backend is currently maintained by:
 
 * [Cori Smith](https://github.com/7RedViolin/)
+
+## Installation
+This can be install via pip from PyPI or using pySigma's plugin functionality
+
+### PyPI
+```bash
+pip install pysigma-backend-sentinelone
+```
+
+### pySigma
+```python
+from sigma.plugins import SigmaPluginDirectory
+plugins = SigmaPluginDirectory.default_plugin_directory()
+plugins.get_plugin_by_id("sentinelone).install()
+```
+
+## Usage
+
+### sigma-cli
+```bash
+sigma convert -t sentinelone proc_creation_win_office_onenote_susp_child_processes.yml
+```
+
+### pySigma
+```python
+from sigma.backends.sentinelone import SentinelOneBackend
+from sigma.rule import SigmaRule
+
+rule = SigmaRule.from_yaml("""
+title: Invoke-Mimikatz CommandLine
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine|contains: Invoke-Mimikatz
+    condition: sel""")
+
+
+backend = SentinelOneBackend()
+print(backend.convert_rule(rule)[0])
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-sentinelone"
-version = "0.1.0"
+version = "0.1.1"
 description = "pySigma SentinelOne backend"
 authors = ["Cori Smith <cs2718281@gmail.com>"]
 license = "MIT"

--- a/sigma/backends/sentinelone/sentinelone.py
+++ b/sigma/backends/sentinelone/sentinelone.py
@@ -44,7 +44,7 @@ class SentinelOneBackend(TextQueryBackend):
     escape_char     : ClassVar[str] = "\\"
     wildcard_multi  : ClassVar[str] = "*"
     wildcard_single : ClassVar[str] = "*"
-    add_escaped     : ClassVar[str] = "\\"
+    add_escaped     : ClassVar[str] = ""
     filter_chars    : ClassVar[str] = ""
     bool_values     : ClassVar[Dict[bool, str]] = {
         True: "true",

--- a/sigma/pipelines/sentinelone/sentinelone.py
+++ b/sigma/pipelines/sentinelone/sentinelone.py
@@ -18,6 +18,11 @@ class InvalidFieldTransformation(DetectionItemFailureTransformation):
 
 def sentinelone_pipeline() -> ProcessingPipeline:
 
+    general_supported_fields = [
+        'ObjectType',
+        'EventType'
+    ]
+
     translation_dict = {
         'process_creation':{                
             "ProcessId":"TgtProcPID",
@@ -359,7 +364,7 @@ def sentinelone_pipeline() -> ProcessingPipeline:
             transformation=InvalidFieldTransformation("This pipeline only supports the following fields:\n{" + 
             '}, {'.join(sorted(set(sum([list(translation_dict[x].keys()) for x in translation_dict.keys()],[])))) + '}'),
             field_name_conditions=[
-                ExcludeFieldCondition(fields=set(sum([list(translation_dict[x].keys()) for x in translation_dict.keys()],[])))
+                ExcludeFieldCondition(fields=list(set(sum([list(translation_dict[x].keys()) for x in translation_dict.keys()],[]))) + general_supported_fields)
             ]
         )
     ]

--- a/tests/test_backend_sentinelone.py
+++ b/tests/test_backend_sentinelone.py
@@ -118,7 +118,7 @@ def test_sentinelone_cidr_query(sentinelone_backend : SentinelOneBackend):
             title: Test
             status: test
             logsource:
-                category: firewall
+                category: network_connection
                 product: test_product
             detection:
                 sel:

--- a/tests/test_backend_sentinelone.py
+++ b/tests/test_backend_sentinelone.py
@@ -125,7 +125,7 @@ def test_sentinelone_cidr_query(sentinelone_backend : SentinelOneBackend):
                     DestinationIp|cidr: 192.168.0.0/16
                 condition: sel
         """)
-    ) == ['ObjectType In ("DNS","Url","IP") AND DstIP startswithCIS "192.168."']
+    ) == ['(ObjectType In ("DNS","Url","IP")) AND DstIP startswithCIS "192.168."']
 
 def test_sentinelone_enum_query(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(

--- a/tests/test_backend_sentinelone.py
+++ b/tests/test_backend_sentinelone.py
@@ -20,7 +20,7 @@ def test_sentinelone_and_expression(sentinelone_backend : SentinelOneBackend):
                     ParentImage: valueB
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (TgtProcName = "valueA" AND SrcProcName = "valueB")']
+    ) == ['EventType = "Process Creation" AND (TgtProcImagePath = "valueA" AND SrcProcImagePath = "valueB")']
 
 def test_sentinelone_or_expression(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -37,7 +37,7 @@ def test_sentinelone_or_expression(sentinelone_backend : SentinelOneBackend):
                     ParentImage: valueB
                 condition: 1 of sel*
         """)
-    ) == ['EventType = "Process Creation" AND (TgtProcName = "valueA" OR SrcProcName = "valueB")']
+    ) == ['EventType = "Process Creation" AND (TgtProcImagePath = "valueA" OR SrcProcImagePath = "valueB")']
 
 def test_sentinelone_and_or_expression(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -57,7 +57,7 @@ def test_sentinelone_and_or_expression(sentinelone_backend : SentinelOneBackend)
                         - valueB2
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND ((TgtProcName In Contains AnyCase ("valueA1","valueA2")) AND (SrcProcName In Contains AnyCase ("valueB1","valueB2")))']
+    ) == ['EventType = "Process Creation" AND ((TgtProcImagePath In Contains AnyCase ("valueA1","valueA2")) AND (SrcProcImagePath In Contains AnyCase ("valueB1","valueB2")))']
 
 def test_sentinelone_or_and_expression(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -76,7 +76,7 @@ def test_sentinelone_or_and_expression(sentinelone_backend : SentinelOneBackend)
                     ParentImage: valueB2
                 condition: 1 of sel*
         """)
-    ) == ['EventType = "Process Creation" AND ((TgtProcName = "valueA1" AND SrcProcName = "valueB1") OR (TgtProcName = "valueA2" AND SrcProcName = "valueB2"))']
+    ) == ['EventType = "Process Creation" AND ((TgtProcImagePath = "valueA1" AND SrcProcImagePath = "valueB1") OR (TgtProcImagePath = "valueA2" AND SrcProcImagePath = "valueB2"))']
 
 def test_sentinelone_in_expression(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -94,7 +94,7 @@ def test_sentinelone_in_expression(sentinelone_backend : SentinelOneBackend):
                         - valueC*
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (TgtProcName = "valueA" OR TgtProcName = "valueB" OR TgtProcName startswithCIS "valueC")']
+    ) == ['EventType = "Process Creation" AND (TgtProcImagePath = "valueA" OR TgtProcImagePath = "valueB" OR TgtProcImagePath startswithCIS "valueC")']
 
 def test_sentinelone_regex_query(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -110,7 +110,7 @@ def test_sentinelone_regex_query(sentinelone_backend : SentinelOneBackend):
                     ParentImage: foo
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (TgtProcName RegExp "foo.*bar" AND SrcProcName = "foo")']
+    ) == ['EventType = "Process Creation" AND (TgtProcImagePath RegExp "foo.*bar" AND SrcProcImagePath = "foo")']
 
 def test_sentinelone_cidr_query(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -118,14 +118,14 @@ def test_sentinelone_cidr_query(sentinelone_backend : SentinelOneBackend):
             title: Test
             status: test
             logsource:
-                category: process_creation
+                category: firewall
                 product: test_product
             detection:
                 sel:
-                    field|cidr: 192.168.0.0/16
+                    DestinationIp|cidr: 192.168.0.0/16
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND field startswithCIS "192.168."']
+    ) == ['ObjectType In ("DNS","Url","IP") AND DstIP startswithCIS "192.168."']
 
 def test_sentinelone_enum_query(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -158,7 +158,7 @@ def test_sentinelone_default_output(sentinelone_backend : SentinelOneBackend):
                     Image: valueA
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND TgtProcName = "valueA"']
+    ) == ['EventType = "Process Creation" AND TgtProcImagePath = "valueA"']
 
 def test_sentinelone_json_output(sentinelone_backend : SentinelOneBackend):
     """Test for output format default."""
@@ -174,7 +174,7 @@ def test_sentinelone_json_output(sentinelone_backend : SentinelOneBackend):
                     Image: valueA
                 condition: sel
         """), "json"
-    ) == {"queries":[{"query":'EventType = "Process Creation" AND TgtProcName = "valueA"', "title":"Test", "id":None, "description":None}]}
+    ) == {"queries":[{"query":'EventType = "Process Creation" AND TgtProcImagePath = "valueA"', "title":"Test", "id":None, "description":None}]}
 
 
 

--- a/tests/test_pipelines_sentinelone.py
+++ b/tests/test_pipelines_sentinelone.py
@@ -19,7 +19,7 @@ def test_sentinelone_windows_os_filter(sentinelone_backend : SentinelOneBackend)
                     Image: valueA
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (EndpointOS = "windows" AND TgtProcName = "valueA")']
+    ) == ['EventType = "Process Creation" AND (EndpointOS = "windows" AND TgtProcImagePath = "valueA")']
 
 def test_sentinelone_linux_os_filter(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -34,7 +34,7 @@ def test_sentinelone_linux_os_filter(sentinelone_backend : SentinelOneBackend):
                     Image: valueA
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (EndpointOS = "linux" AND TgtProcName = "valueA")']
+    ) == ['EventType = "Process Creation" AND (EndpointOS = "linux" AND TgtProcImagePath = "valueA")']
 
 def test_sentinelone_osx_os_filter(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -49,7 +49,7 @@ def test_sentinelone_osx_os_filter(sentinelone_backend : SentinelOneBackend):
                     Image: valueA
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (EndpointOS = "osx" AND TgtProcName = "valueA")']
+    ) == ['EventType = "Process Creation" AND (EndpointOS = "osx" AND TgtProcImagePath = "valueA")']
 
 def test_sentinelone_process_creation_mapping(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -79,12 +79,12 @@ def test_sentinelone_process_creation_mapping(sentinelone_backend : SentinelOneB
                     ParentCommandLine: Get-Path
                 condition: sel
         """)
-    ) == ['EventType = "Process Creation" AND (TgtProcPID = "12" AND TgtProcName = "valueA" AND TgtProcDisplayName = "foo bar" AND ' +
+    ) == ['EventType = "Process Creation" AND (TgtProcPID = "12" AND TgtProcImagePath = "valueA" AND TgtProcDisplayName = "foo bar" AND ' +
           'TgtProcDisplayName = "bar foo" AND TgtProcPublisher = "foo foo" AND TgtProcCmdLine = "invoke-mimikatz" AND ' +
           'TgtProcImagePath = "/etc" AND TgtProcUser = "administrator" AND TgtProcSessionId = "4" AND ' +
           'TgtProcIntegrityLevel = "bar bar" AND TgtProcMd5 = "asdfasdfasdfasdfasdf" AND ' + 
           'TgtProcSha1 = "asdfasdfasdfasdfasdfasdf" AND TgtProcSha256 = "asdfasdfasdfasdfasdfasdfasdfasdf" AND SrcProcPID = "13" AND ' +
-          'SrcProcName = "valueB" AND SrcProcCmdLine = "Get-Path")']
+          'SrcProcImagePath = "valueB" AND SrcProcCmdLine = "Get-Path")']
 
 def test_sentinelone_file_mapping(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -105,8 +105,8 @@ def test_sentinelone_file_mapping(sentinelone_backend : SentinelOneBackend):
                     User: administrator
                 condition: sel
         """)
-    ) == ['ObjectType = "File" AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND TgtFilePath = "foo bar" AND ' + 
+    ) == ['ObjectType = "File" AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND TgtFilePath = "foo bar" AND ' + 
           'TgtFileOldPath = "bar foo" AND SrcProcUser = "administrator")']
 
 def test_sentinelone_image_load_mapping(sentinelone_backend : SentinelOneBackend):
@@ -128,8 +128,8 @@ def test_sentinelone_image_load_mapping(sentinelone_backend : SentinelOneBackend
                     ImageLoaded: foo bar
                 condition: sel
         """)
-    ) == ['EventType = "ModuleLoad" AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND ModuleSha1 = "asdfasdf" AND ' + 
+    ) == ['EventType = "ModuleLoad" AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND ModuleSha1 = "asdfasdf" AND ' + 
           'ModuleMd5 = "asdfasdfasdf" AND ModulePath = "foo bar")']
 
 def test_sentinelone_pipe_creation_mapping(sentinelone_backend : SentinelOneBackend):
@@ -149,8 +149,8 @@ def test_sentinelone_pipe_creation_mapping(sentinelone_backend : SentinelOneBack
                     PipeName: foo bar
                 condition: sel
         """)
-    ) == ['EventType = "Named Pipe Creation" AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND NamedPipeName = "foo bar")']
+    ) == ['EventType = "Named Pipe Creation" AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND NamedPipeName = "foo bar")']
 
 def test_sentinelone_registry_mapping(sentinelone_backend : SentinelOneBackend):
     assert sentinelone_backend.convert(
@@ -170,8 +170,8 @@ def test_sentinelone_registry_mapping(sentinelone_backend : SentinelOneBackend):
                     Details: bar foo
                 condition: sel
         """)
-    ) == ['ObjectType = "Registry" AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND RegistryKeyPath = "foo bar" AND ' + 
+    ) == ['ObjectType = "Registry" AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND RegistryKeyPath = "foo bar" AND ' + 
           'RegistryValue = "bar foo")']
 
 def test_sentinelone_dns_mapping(sentinelone_backend : SentinelOneBackend):
@@ -194,8 +194,8 @@ def test_sentinelone_dns_mapping(sentinelone_backend : SentinelOneBackend):
                     record_type: bar bar
                 condition: sel
         """)
-    ) == ['ObjectType = "DNS" AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND DnsRequest = "foo bar" AND ' + 
+    ) == ['ObjectType = "DNS" AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' +
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND DnsRequest = "foo bar" AND ' + 
           'DnsResponse = "bar foo" AND DnsRequest = "foo foo" AND DnsResponse = "bar bar")']
 
 def test_sentinelone_network_mapping(sentinelone_backend : SentinelOneBackend):
@@ -225,8 +225,8 @@ def test_sentinelone_network_mapping(sentinelone_backend : SentinelOneBackend):
                     src_port: 8080
                 condition: sel
         """)
-    ) == ['(ObjectType In ("DNS","Url","IP")) AND (SrcProcName = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' + 
-          'SrcProcParentName = "valueB" AND SrcProcParentCmdline = "Get-Path" AND (Url = "foo bar" OR DnsRequest = "foo bar") AND ' + 
+    ) == ['(ObjectType In ("DNS","Url","IP")) AND (SrcProcImagePath = "valueA" AND SrcProcCmdLine = "invoke-mimikatz" AND ' + 
+          'SrcProcParentImagePath = "valueB" AND SrcProcParentCmdline = "Get-Path" AND (Url = "foo bar" OR DnsRequest = "foo bar") AND ' + 
           'DstPort = "445" AND DstIP = "0.0.0.0" AND SrcProcUser = "administrator" AND SrcIP = "1.1.1.1" AND SrcPort = "135" AND ' + 
           'NetProtocolName = "udp" AND DstIP = "2.2.2.2" AND SrcIP = "3.3.3.3" AND DstPort = "80" AND SrcPort = "8080")']
 
@@ -245,8 +245,22 @@ def test_sentinelone_unsupported_rule_type(sentinelone_backend : SentinelOneBack
                     CommandLine: invoke-mimikatz
                     ParentImage: valueB
                     ParentCommandLine: Get-Path
-                    TargetObject: foo bar
-                    Details: bar foo
+                condition: sel
+        """)
+    )
+
+def test_sentinelone_unsupported_field_name(sentinelone_backend : SentinelOneBackend):
+  with pytest.raises(ValueError):
+    sentinelone_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    FOO: bar
                 condition: sel
         """)
     )


### PR DESCRIPTION
Changes
- Updated pipeline to raise errors if there is an unsupported field name 
- Update pipeline to map `Image` and `ParentImage` to `TgtProcImagePath`, `SrcProcImagePath`, and `SrcProcParentImagePath` as appropriate
- Update backend to not escape `\` characters within quotes.

Closes #1 
Closes #2