### PR TITLE
Add Support for SentinelOne PQ

### DIFF
--- a/sigma/backends/sentinelone/__init__.py
+++ b/sigma/backends/sentinelone/__init__.py
@@ -1,5 +1,7 @@
 from .sentinelone import SentinelOneBackend
+from .sentinelone_pq import SentinelOnePQBackend
 
 backends = {
     "sentinelone": SentinelOneBackend,
+    "sentinelone_pq": SentinelOnePQBackend
 }

--- a/sigma/backends/sentinelone/sentinelone.py
+++ b/sigma/backends/sentinelone/sentinelone.py
@@ -69,7 +69,7 @@ class SentinelOneBackend(TextQueryBackend):
         SigmaCompareExpression.CompareOperators.GTE : ">=",
     }
 
-    field_null_expression : ClassVar[str] = "{field} IS NOT EMPTY"
+    field_null_expression : ClassVar[str] = "{field} IS EMPTY"
 
     field_exists_expression : ClassVar[str] = "{field} EXISTS"             # Expression for field existence as format string with {field} placeholder for field name
     field_not_exists_expression : ClassVar[str] = "NOT {field} EXISTS"      # Expression for field non-existence as format string with {field} placeholder for field name. If not set, field_exists_expression is negated with boolean NOT.

--- a/sigma/backends/sentinelone/sentinelone_pq.py
+++ b/sigma/backends/sentinelone/sentinelone_pq.py
@@ -1,0 +1,110 @@
+from sigma.conversion.state import ConversionState
+from sigma.rule import SigmaRule
+from sigma.processing.pipeline import ProcessingPipeline
+from sigma.conversion.base import TextQueryBackend
+from sigma.conditions import ConditionItem, ConditionAND, ConditionOR, ConditionNOT, ConditionFieldEqualsValueExpression
+from sigma.types import SigmaCompareExpression, SigmaRegularExpression, SigmaString
+from sigma.pipelines.sentinelone import sentinelonepq_pipeline
+from sigma.conversion.deferred import DeferredQueryExpression
+import re
+from typing import ClassVar, Dict, Tuple, Pattern, List, Any, Union
+
+class SentinelOnePQBackend(TextQueryBackend):
+    """SentinelOne PowerQuery backend."""
+
+    backend_processing_pipeline: ClassVar[ProcessingPipeline] = sentinelonepq_pipeline()
+
+    name : ClassVar[str] = "SentinelOne PowerQuery backend"
+    formats : Dict[str, str] = {
+        "default": "Plaintext",
+        "json": "JSON format"
+    }
+
+    requires_pipeline : bool = False
+
+    precedence : ClassVar[Tuple[ConditionItem, ConditionItem, ConditionItem]] = (ConditionNOT, ConditionAND, ConditionOR)
+    parenthesize : bool = True
+    group_expression : ClassVar[str] = "({expr})"
+
+    token_separator : str = " "
+    or_token : ClassVar[str] = "or"
+    and_token : ClassVar[str] = "and"
+    not_token : ClassVar[str] = "not"
+    eq_token : ClassVar[str] = "="
+
+    field_quote : ClassVar[str] = "'"
+    field_quote_pattern : ClassVar[Pattern] = re.compile("^\\w\.+$")
+    field_quote_pattern_negation : ClassVar[bool] = False
+
+    field_escape : ClassVar[str] = "\\"
+    field_escape_quote : ClassVar[bool] = True
+    field_escape_pattern : ClassVar[Pattern] = re.compile("\\s")
+
+    str_quote       : ClassVar[str] = '"'
+    escape_char     : ClassVar[str] = "\\"
+    wildcard_multi  : ClassVar[str] = "*"
+    wildcard_single : ClassVar[str] = "*"
+    add_escaped     : ClassVar[str] = ""
+    filter_chars    : ClassVar[str] = ""
+    bool_values     : ClassVar[Dict[bool, str]] = {
+        True: "true",
+        False: "false",
+    }
+
+    startswith_expression : ClassVar[str] = "{field} contains {value}"
+    endswith_expression   : ClassVar[str] = "{field} contains {value}"
+    contains_expression   : ClassVar[str] = "{field} contains {value}"
+
+    re_expression : ClassVar[str] = "{field} matches \"{regex}\""
+    re_escape_char : ClassVar[str] = "\\"
+    re_escape : ClassVar[Tuple[str]] = ()
+    re_escape_escape_char : bool = True
+    re_flag_prefix : bool = False
+
+    # Case sensitive string matching expression. String is quoted/escaped like a normal string.
+    # Placeholders {field} and {value} are replaced with field name and quoted/escaped string.
+    case_sensitive_match_expression : ClassVar[str] = "{field} == {value}"
+    # Case sensitive string matching operators similar to standard string matching. If not provided,
+    # case_sensitive_match_expression is used.
+    case_sensitive_startswith_expression : ClassVar[str] = "{field} contains:matchcase {value}"
+    case_sensitive_endswith_expression   : ClassVar[str] = "{field} contains:matchcase {value}"
+    case_sensitive_contains_expression   : ClassVar[str] = "{field} contains:matchcase {value}"
+
+    compare_op_expression : ClassVar[str] = "{field} {operator} {value}"
+    compare_operators : ClassVar[Dict[SigmaCompareExpression.CompareOperators, str]] = {
+        SigmaCompareExpression.CompareOperators.LT  : "<",
+        SigmaCompareExpression.CompareOperators.LTE : "<=",
+        SigmaCompareExpression.CompareOperators.GT  : ">",
+        SigmaCompareExpression.CompareOperators.GTE : ">=",
+    }
+
+    field_null_expression : ClassVar[str] = 'not ({field} matches "\\.*")'
+
+    field_exists_expression : ClassVar[str] = '{field} matches "\\.*"'             # Expression for field existence as format string with {field} placeholder for field name
+    field_not_exists_expression : ClassVar[str] = 'not ({field} matches "\\.*")'      # Expression for field non-existence as format string with {field} placeholder for field name. If not set, field_exists_expression is negated with boolean NOT.
+
+    convert_or_as_in : ClassVar[bool] = True                     # Convert OR as in-expression
+    convert_and_as_in : ClassVar[bool] = False                    # Convert AND as in-expression
+    in_expressions_allow_wildcards : ClassVar[bool] = False       # Values in list can contain wildcards. If set to False (default) only plain values are converted into in-expressions.
+    field_in_list_expression : ClassVar[str] = "{field} {op} ({list})"  # Expression for field in list of values as format string with placeholders {field}, {op} and {list}
+    or_in_operator : ClassVar[str] = "in"               # Operator used to convert OR into in-expressions. Must be set if convert_or_as_in is set
+    list_separator : ClassVar[str] = ","               # List element separator
+
+    unbound_value_str_expression : ClassVar[str] = '"{value}"'
+    unbound_value_num_expression : ClassVar[str] = '"{value}"'
+
+    def finalize_query_default(self, rule: SigmaRule, query: str, index: int, state: ConversionState) -> str:
+        query += ' | columns ' + ",".join(rule.fields) if rule.fields else ''
+        return query
+
+    def finalize_output_default(self, queries: List[str]) -> str:
+        return queries
+
+    def finalize_query_json(self, rule: SigmaRule, query: str, index: int, state:ConversionState) -> dict:
+        query += ' | columns ' + ",".join(rule.fields) if rule.fields else ''
+        return {"query":query, "title":rule.title, "id":rule.id, "description": rule.description}
+    
+    def finalize_output_json(self, queries: List[str]) -> dict:
+        return {"queries":queries}
+    
+    

--- a/sigma/pipelines/sentinelone/__init__.py
+++ b/sigma/pipelines/sentinelone/__init__.py
@@ -1,5 +1,7 @@
 from .sentinelone import sentinelone_pipeline
+from .sentinelone_pq import sentinelonepq_pipeline
 
 pipelines = {
     "sentinelone_pipeline": sentinelone_pipeline,
+    "sentinelonepq_pipeline": sentinelonepq_pipeline,
 }

--- a/sigma/pipelines/sentinelone/sentinelone_pq.py
+++ b/sigma/pipelines/sentinelone/sentinelone_pq.py
@@ -1,0 +1,384 @@
+from sigma.processing.conditions import LogsourceCondition
+from sigma.processing.transformations import AddConditionTransformation, FieldMappingTransformation, DetectionItemFailureTransformation, RuleFailureTransformation, SetStateTransformation, ChangeLogsourceTransformation
+from sigma.processing.conditions import LogsourceCondition, IncludeFieldCondition, ExcludeFieldCondition, RuleProcessingItemAppliedCondition
+from sigma.processing.pipeline import ProcessingItem, ProcessingPipeline
+from sigma.rule import SigmaDetectionItem
+from sigma.exceptions import SigmaTransformationError
+
+class InvalidFieldTransformation(DetectionItemFailureTransformation):
+    """
+    Overrides the apply_detection_item() method from DetectionItemFailureTransformation to also include the field name
+    in the error message
+    """
+
+    def apply_detection_item(self, detection_item: SigmaDetectionItem) -> None:
+        field_name = detection_item.field
+        self.message = f"Invalid SigmaDetectionItem field name encountered: {field_name}. " + self.message
+        raise SigmaTransformationError(self.message)
+
+def sentinelonepq_pipeline() -> ProcessingPipeline:
+
+    general_supported_fields = [
+        'event.category',
+        'event.type'
+    ]
+
+    translation_dict = {
+        'process_creation':{
+            "ProcessId":"tgt.process.pid",
+            "Image":"tgt.process.image.path",
+            "Description":"tgt.process.displayName", #Not sure whether this should be Description or Product???
+            "Publisher": "tgt.process.publisher",
+            "Product":"tgt.process.displayName",
+            "Company":"tgt.process.publisher",
+            "CommandLine":"tgt.process.cmdline",
+            "CurrentDirectory":"tgt.process.image.path",
+            "User":"tgt.process.user",
+            "TerminalSessionId":"tgt.process.sessionid",
+            "IntegrityLevel":"tgt.process.integrityLevel",
+            "md5":"tgt.process.image.md5",
+            "sha1":"tgt.process.image.sha1",
+            "sha256":"tgt.process.image.sha256",
+            "ParentProcessId":"src.process.pid",
+            "ParentImage":"src.process.image.path",
+            "ParentCommandLine":"src.process.cmdline",
+        },
+        'file':{
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+            "TargetFilename":"tgt.file.path", 
+            "SourceFilename":"tgt.file.oldPath",
+            "User":"src.process.user"
+        },
+        'image_load':{
+            "ImageLoaded":"module.path",
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+            "sha1":"module.sha1",
+            "md5": "module.md5"
+        },
+        'pipe_creation':{
+            "PipeName":"namedPipe.name",
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+        },
+        'registry':{
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+            "TargetObject": "registry.keyPath",
+            "Details": "registry.value"
+        },
+        'dns':{
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+            "query": "event.dns.request",
+            "answer":"event.dns.response",
+            "QueryName": "event.dns.request",
+            "record_type":"event.dns.response"
+        },
+        'network':{
+            "Image": "src.process.image.path",
+            "CommandLine":"src.process.cmdline",
+            "ParentImage":"src.process.parent.image.path",
+            "ParentCommandLine":"src.process.parent.cmdline",
+            "DestinationHostname":["url.address", "event.dns.request"],
+            "DestinationPort":"dst.port.number",
+            "DestinationIp":"dst.ip.address",
+            "User":"src.process.user",
+            "SourceIp":"src.ip.address",
+            "SourcePort":"src.port.number",
+            "Protocol":"NetProtocolName",
+            "dst_ip":"dst.ip.address",
+            "src_ip":"src.ip.address",
+            "dst_port":"dst.port.number",
+            "src_port":"src.port.number"
+        }
+    }
+
+    os_filter = [
+        # Add EndpointOS = Linux
+        ProcessingItem(
+            identifier="s1_pq_linux_product",
+            transformation=AddConditionTransformation({
+                "endpoint.os": "linux"
+            }),
+            rule_conditions=[
+                LogsourceCondition(product="linux")
+            ]
+        ),
+        # Add EndpointOS = Windows
+        ProcessingItem(
+            identifier="s1_pq_windows_product",
+            transformation=AddConditionTransformation({
+                "endpoint.os": "windows"
+            }),
+            rule_conditions=[
+                LogsourceCondition(product="windows")
+            ]
+        ),
+        # Add EndpointOS = OSX
+        ProcessingItem(
+            identifier="s1_pq_osx_product",
+            transformation=AddConditionTransformation({
+                "endpoint.os":"osx"
+            }),
+            rule_conditions=[
+                LogsourceCondition(product="macos")
+            ]
+        )
+    ]
+
+    object_event_type_filter = [
+        # Add EventType = Process Creation
+        ProcessingItem(
+            identifier="s1_pq_process_creation_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "Process Creation"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="process_creation")
+            ]
+        ),
+        # Add ObjectType = "File"
+        ProcessingItem(
+            identifier="s1_pq_file_event_objecttype",
+            transformation=AddConditionTransformation({
+                "event.category": "file"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="file_event")
+            ]
+        ),
+        # Add EventType = "File Modification"
+        ProcessingItem(
+            identifier="s1_pq_file_change_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "File Modification"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="file_change")
+            ]
+        ),
+        # Add EventType = "File Rename"
+        ProcessingItem(
+            identifier="s1_pq_file_rename_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "File Rename"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="file_rename")
+            ]
+        ),
+        # Add EventType = "File Delete"
+        ProcessingItem(
+            identifier="s1_pq_file_delete_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "File Delete"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="file_delete")
+            ]
+        ),
+        # Add EventType = "Module Load"
+        ProcessingItem(
+            identifier="s1_pq_image_load_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "ModuleLoad"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="image_load")
+            ]
+        ),
+        # Add EventType for Pipe Creation
+        ProcessingItem(
+            identifier="s1_pq_pipe_creation_eventtype",
+            transformation=AddConditionTransformation({
+                "event.type": "Named Pipe Creation"
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="pipe_creation")
+            ]
+        ),
+        # Add ObjectType for Registry Stuff
+        ProcessingItem(
+            identifier="s1_pq_registry_eventtype",
+            transformation=AddConditionTransformation({
+                "event.category": "Registry"
+            }),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="registry_add"),
+                LogsourceCondition(category="registry_delete"),
+                LogsourceCondition(category="registry_event"),
+                LogsourceCondition(category="registry_set")
+            ]
+        ),
+        # Add ObjectType for DNS Stuff
+        ProcessingItem(
+            identifier="s1_pq_dns_objecttype",
+            transformation=AddConditionTransformation({
+                "event.category":"DNS"
+            }),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="dns_query"),
+                LogsourceCondition(category="dns")
+            ]
+        ),
+        # Add ObjectType for Network Stuff
+        ProcessingItem(
+            identifier="s1_pq_network_objecttype",
+            transformation=AddConditionTransformation({
+                "event.category": ["DNS","Url","IP"]
+            }),
+            rule_conditions=[
+                LogsourceCondition(category="network_connection")
+            ]
+        )
+    ]
+
+    field_mappings = [
+        # Process Creation
+        ProcessingItem(
+            identifier="s1_pq_process_creation_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['process_creation']),
+            rule_conditions=[
+                LogsourceCondition(category="process_creation")
+            ]
+        ),
+        # File Stuff
+        ProcessingItem(
+            identifier="s1_pq_file_change_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['file']),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="file_change"),
+                LogsourceCondition(category="file_rename"),
+                LogsourceCondition(category="file_delete"),
+                LogsourceCondition(category="file_event")
+            ]
+        ),
+        # Module Load Stuff
+        ProcessingItem(
+            identifier="s1_pq_image_load_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['image_load']),
+            rule_conditions=[
+                LogsourceCondition(category="image_load")
+            ]
+        ),
+        # Pipe Creation Stuff
+        ProcessingItem(
+            identifier="s1_pq_pipe_creation_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['pipe_creation']),
+            rule_conditions=[
+                LogsourceCondition(category="pipe_creation")
+            ]
+        ),
+        # Registry Stuff
+        ProcessingItem(
+            identifier="s1_pq_registry_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['registry']),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="registry_add"),
+                LogsourceCondition(category="registry_delete"),
+                LogsourceCondition(category="registry_event"),
+                LogsourceCondition(category="registry_set")
+            ]
+        ),
+        # DNS Stuff
+        ProcessingItem(
+            identifier="s1_pq_dns_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['dns']),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="dns_query"),
+                LogsourceCondition(category="dns")
+            ]
+        ),
+        # Network Stuff
+        ProcessingItem(
+            identifier="s1_pq_network_fieldmapping",
+            transformation=FieldMappingTransformation(translation_dict['network']),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="network_connection"),
+                LogsourceCondition(category="firewall")
+            ]
+        )
+    ]
+
+    change_logsource_info = [
+        # Add service to be SentinelOne for pretty much everything
+        ProcessingItem(
+            identifier="s1_pq_logsource",
+            transformation=ChangeLogsourceTransformation(
+                service="sentinelone"
+            ),
+            rule_condition_linking=any,
+            rule_conditions=[
+                LogsourceCondition(category="process_creation"),
+                LogsourceCondition(category="file_change"),
+                LogsourceCondition(category="file_rename"),
+                LogsourceCondition(category="file_delete"),
+                LogsourceCondition(category="file_event"),
+                LogsourceCondition(category="image_load"),
+                LogsourceCondition(category="pipe_creation"),
+                LogsourceCondition(category="registry_add"),
+                LogsourceCondition(category="registry_delete"),
+                LogsourceCondition(category="registry_event"),
+                LogsourceCondition(category="registry_set"),
+                LogsourceCondition(category="dns"),
+                LogsourceCondition(category="dns_query"),
+                LogsourceCondition(category="network_connection"),
+                LogsourceCondition(category="firewall")
+            ]
+        ),
+    ]
+
+    unsupported_rule_types = [
+        # Show error if unsupported option
+        ProcessingItem(
+            identifier="s1_pq_fail_rule_not_supported",
+            rule_condition_linking=any,
+            transformation=RuleFailureTransformation("Rule type not yet supported by the SentinelOne PQ Sigma backend"),
+            rule_condition_negation=True,
+            rule_conditions=[
+                RuleProcessingItemAppliedCondition("s1_pq_logsource")
+            ]
+        )
+    ]
+
+    unsupported_field_name = [
+        ProcessingItem(
+            identifier='s1_pq_fail_field_not_supported',
+            transformation=InvalidFieldTransformation("This pipeline only supports the following fields:\n{" + 
+            '}, {'.join(sorted(set(sum([list(translation_dict[x].keys()) for x in translation_dict.keys()],[])))) + '}'),
+            field_name_conditions=[
+                ExcludeFieldCondition(fields=list(set(sum([list(translation_dict[x].keys()) for x in translation_dict.keys()],[]))) + general_supported_fields)
+            ]
+        )
+    ]
+
+    return ProcessingPipeline(
+        name="SentinelOne PQ pipeline",
+        priority=50,
+        items = [
+            *unsupported_field_name,
+            *os_filter,
+            *object_event_type_filter,
+            *field_mappings,
+            *change_logsource_info,
+            *unsupported_rule_types,
+        ]
+    )

--- a/tests/test_backend_sentinelone_pq.py
+++ b/tests/test_backend_sentinelone_pq.py
@@ -1,0 +1,163 @@
+import pytest
+from sigma.collection import SigmaCollection
+from sigma.backends.sentinelone import SentinelOnePQBackend
+
+@pytest.fixture
+def sentinelone_pq_backend():
+    return SentinelOnePQBackend()
+
+def test_sentinelone_pq_and_expression(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    ParentImage: valueB
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (tgt.process.image.path="valueA" and src.process.image.path="valueB")']
+
+def test_sentinelone_pq_or_expression(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel1:
+                    Image: valueA
+                sel2:
+                    ParentImage: valueB
+                condition: 1 of sel*
+        """)
+    ) == ['event.type="Process Creation" and (tgt.process.image.path="valueA" or src.process.image.path="valueB")']
+
+def test_sentinelone_pq_and_or_expression(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image:
+                        - valueA1
+                        - valueA2
+                    ParentImage:
+                        - valueB1
+                        - valueB2
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and ((tgt.process.image.path in ("valueA1","valueA2")) and (src.process.image.path in ("valueB1","valueB2")))']
+
+def test_sentinelone_pq_or_and_expression(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel1:
+                    Image: valueA1
+                    ParentImage: valueB1
+                sel2:
+                    Image: valueA2
+                    ParentImage: valueB2
+                condition: 1 of sel*
+        """)
+    ) == ['event.type="Process Creation" and ((tgt.process.image.path="valueA1" and src.process.image.path="valueB1") or (tgt.process.image.path="valueA2" and src.process.image.path="valueB2"))']
+
+def test_sentinelone_pq_in_expression(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image:
+                        - valueA
+                        - valueB
+                        - valueC*
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (tgt.process.image.path="valueA" or tgt.process.image.path="valueB" or tgt.process.image.path contains "valueC")']
+
+def test_sentinelone_pq_regex_query(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image|re: foo.*bar
+                    ParentImage: foo
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (tgt.process.image.path matches "foo.*bar" and src.process.image.path="foo")']
+
+def test_sentinelone_pq_cidr_query(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: network_connection
+                product: test_product
+            detection:
+                sel:
+                    DestinationIp|cidr: 192.168.0.0/16
+                condition: sel
+        """)
+    ) == ['(event.category in ("DNS","Url","IP")) and dst.ip.address contains "192.168."']
+
+def test_sentinelone_pq_default_output(sentinelone_pq_backend : SentinelOnePQBackend):
+    """Test for output format default."""
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and tgt.process.image.path="valueA"']
+
+def test_sentinelone_pq_json_output(sentinelone_pq_backend : SentinelOnePQBackend):
+    """Test for output format default."""
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                condition: sel
+        """), "json"
+    ) == {"queries":[{"query":'event.type="Process Creation" and tgt.process.image.path="valueA"', "title":"Test", "id":None, "description":None}]}
+
+
+

--- a/tests/test_pipelines_sentinelone_pq.py
+++ b/tests/test_pipelines_sentinelone_pq.py
@@ -1,0 +1,249 @@
+import pytest
+from sigma.collection import SigmaCollection
+from sigma.backends.sentinelone import SentinelOnePQBackend
+
+@pytest.fixture
+def sentinelone_pq_backend():
+    return SentinelOnePQBackend()
+
+def test_sentinelone_pq_windows_os_filter(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: windows
+            detection:
+                sel:
+                    Image: valueA
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (endpoint.os="windows" and tgt.process.image.path="valueA")']
+
+def test_sentinelone_pq_linux_os_filter(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: linux
+            detection:
+                sel:
+                    Image: valueA
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (endpoint.os="linux" and tgt.process.image.path="valueA")']
+
+def test_sentinelone_pq_osx_os_filter(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: macos
+            detection:
+                sel:
+                    Image: valueA
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (endpoint.os="osx" and tgt.process.image.path="valueA")']
+
+def test_sentinelone_pq_process_creation_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    ProcessId: 12
+                    Image: valueA
+                    Description: foo bar
+                    Product: bar foo
+                    Company: foo foo
+                    CommandLine: invoke-mimikatz
+                    CurrentDirectory: /etc
+                    User: administrator
+                    TerminalSessionId: 4
+                    IntegrityLevel: bar bar
+                    md5: asdfasdfasdfasdfasdf
+                    sha1: asdfasdfasdfasdfasdfasdf
+                    sha256: asdfasdfasdfasdfasdfasdfasdfasdf
+                    ParentProcessId: 13
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                condition: sel
+        """)
+    ) == ['event.type="Process Creation" and (tgt.process.pid=12 and tgt.process.image.path="valueA" and tgt.process.displayName="foo bar" and tgt.process.displayName="bar foo" and tgt.process.publisher="foo foo" and tgt.process.cmdline="invoke-mimikatz" and tgt.process.image.path="/etc" and tgt.process.user="administrator" and tgt.process.sessionid=4 and tgt.process.integrityLevel="bar bar" and tgt.process.image.md5="asdfasdfasdfasdfasdf" and tgt.process.image.sha1="asdfasdfasdfasdfasdfasdf" and tgt.process.image.sha256="asdfasdfasdfasdfasdfasdfasdfasdf" and src.process.pid=13 and src.process.image.path="valueB" and src.process.cmdline="Get-Path")']
+
+def test_sentinelone_pq_file_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: file_event
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    TargetFilename: foo bar
+                    SourceFilename: bar foo
+                    User: administrator
+                condition: sel
+        """)
+    ) == ['event.category="file" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and tgt.file.path="foo bar" and tgt.file.oldPath="bar foo" and src.process.user="administrator")']
+
+def test_sentinelone_pq_image_load_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: image_load
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    sha1: asdfasdf
+                    md5: asdfasdfasdf
+                    ImageLoaded: foo bar
+                condition: sel
+        """)
+    ) == ['event.type="ModuleLoad" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and module.sha1="asdfasdf" and module.md5="asdfasdfasdf" and module.path="foo bar")']
+
+def test_sentinelone_pq_pipe_creation_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: pipe_creation
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    PipeName: foo bar
+                condition: sel
+        """)
+    ) == ['event.type="Named Pipe Creation" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and namedPipe.name="foo bar")']
+
+def test_sentinelone_pq_registry_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: registry_event
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    TargetObject: foo bar
+                    Details: bar foo
+                condition: sel
+        """)
+    ) == ['event.category="Registry" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and registry.keyPath="foo bar" and registry.value="bar foo")']
+
+def test_sentinelone_pq_dns_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: dns
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    query: foo bar
+                    answer: bar foo
+                    QueryName: foo foo
+                    record_type: bar bar
+                condition: sel
+        """)
+    ) == ['event.category="DNS" and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and event.dns.request="foo bar" and event.dns.response="bar foo" and event.dns.request="foo foo" and event.dns.response="bar bar")']
+
+def test_sentinelone_pq_network_mapping(sentinelone_pq_backend : SentinelOnePQBackend):
+    assert sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: network_connection
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                    DestinationHostname: foo bar
+                    DestinationPort: 445
+                    DestinationIp: 0.0.0.0
+                    User: administrator
+                    SourceIp: 1.1.1.1
+                    SourcePort: 135
+                    Protocol: udp
+                    dst_ip: 2.2.2.2
+                    src_ip: 3.3.3.3
+                    dst_port: 80
+                    src_port: 8080
+                condition: sel
+        """)
+    ) == ['(event.category in ("DNS","Url","IP")) and (src.process.image.path="valueA" and src.process.cmdline="invoke-mimikatz" and src.process.parent.image.path="valueB" and src.process.parent.cmdline="Get-Path" and (url.address="foo bar" or event.dns.request="foo bar") and dst.port.number=445 and dst.ip.address="0.0.0.0" and src.process.user="administrator" and src.ip.address="1.1.1.1" and src.port.number=135 and NetProtocolName="udp" and dst.ip.address="2.2.2.2" and src.ip.address="3.3.3.3" and dst.port.number=80 and src.port.number=8080)']
+
+def test_sentinelone_pq_unsupported_rule_type(sentinelone_pq_backend : SentinelOnePQBackend):
+  with pytest.raises(ValueError):
+    sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: test_category
+                product: test_product
+            detection:
+                sel:
+                    Image: valueA
+                    CommandLine: invoke-mimikatz
+                    ParentImage: valueB
+                    ParentCommandLine: Get-Path
+                condition: sel
+        """)
+    )
+
+def test_sentinelone_pq_unsupported_field_name(sentinelone_pq_backend : SentinelOnePQBackend):
+  with pytest.raises(ValueError):
+    sentinelone_pq_backend.convert(
+        SigmaCollection.from_yaml("""
+            title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    FOO: bar
+                condition: sel
+        """)
+    )


### PR DESCRIPTION
Changes
- Create backend for PQ syntax
- Create pipeline for PQ field names
- Fix logic error in DV backend that incorrectly used `{field} IS NOT EMPTY` when searching for null values

Closes #6 